### PR TITLE
Upgrade to Python 3.8.12 and Alpine 3.15 to avoid installing Rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #---------
 # Python Base
 #---------
-FROM python:3.8.0-alpine3.10 as ubitec_jenkins_python_base
+FROM python:3.8.12-alpine3.15 as ubitec_jenkins_python_base
 
 LABEL name="jenkins-docker-python"
 LABEL version="SHOULD_BE_SPECIFIED"
@@ -46,7 +46,7 @@ RUN apk add --no-cache --virtual .build-deps \
     # successfully. They are installed in a virtual bundle
     # call .build-deps and they will be deleted later.
         libffi-dev openssl-dev make \
-    && pip install ansible==2.9.11 \
+    && pip install ansible==2.9.11 boto3==1.20.20 \
     && apk del .build-deps \
     # Install OpenSSH Client & ssh-agent so that Jenkins Slaves
     # SSH can be used from within the Docker container.

--- a/project.json
+++ b/project.json
@@ -1,6 +1,6 @@
 {
   "base" : {
-    "version" : "1.2.0"
+    "version" : "1.2.1"
   },
   "mkdocs" : {
     "version" : "1.1"


### PR DESCRIPTION
- According to `cryptography` GitHub issue [1], upgrading to Alpine >=
3.12 will avoid installing Rust lang to compile some modules with Rust
  dependencies.
- Install `boto3` for Ansible Playbook using AWS.

[1]: https://github.com/pyca/cryptography/issues/5776